### PR TITLE
fix: 로그인 API 엔드포인트 수정 및 튜토리얼 완료 여부 저장

### DIFF
--- a/src/screens/Auth/LoginScreen.js
+++ b/src/screens/Auth/LoginScreen.js
@@ -11,7 +11,7 @@ import {
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import EyeOpen from "../../components/EyeOpen";
 import EyeClosed from "../../components/EyeClosed";
-import { API_BASE_URL } from "../../utils/apiConfig";
+import { API_BASE_URL, API_ENDPOINTS } from "../../utils/apiConfig";
 
 const LoginScreen = ({ navigation }) => {
   const [seePassword, setSeePassword] = useState(true);
@@ -30,7 +30,7 @@ const LoginScreen = ({ navigation }) => {
     try {
       console.log("로그인 시도:", { email, password: "***" });
 
-      const response = await fetch(`${API_BASE_URL}api/token/`, {
+      const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.LOGIN}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -56,13 +56,21 @@ const LoginScreen = ({ navigation }) => {
         return;
       }
 
-      if (response.ok && data.access) {
+      if (response.ok && data.status === "success") {
+        const { access, refresh, has_completed_tutorial } = data.data;
         console.log("✅ 토큰 발급 성공");
+        console.log("튜토리얼 완료 여부:", has_completed_tutorial);
 
-        await AsyncStorage.setItem("accessToken", data.access);
-        await AsyncStorage.setItem("refreshToken", data.refresh);
+        await AsyncStorage.setItem("accessToken", access);
+        await AsyncStorage.setItem("refreshToken", refresh);
         await AsyncStorage.setItem("userEmail", email);
         await AsyncStorage.setItem("userPassword", password); // ❗ 자동 로그인을 위해 password도 저장
+
+        // 튜토리얼 완료 여부 저장
+        await AsyncStorage.setItem(
+          "hasCompletedTutorial",
+          has_completed_tutorial.toString()
+        );
 
         console.log("🔹 로그인 성공, MainTab으로 이동 시도");
         navigation.navigate("MainTab");

--- a/src/utils/apiConfig.js
+++ b/src/utils/apiConfig.js
@@ -7,8 +7,8 @@ export const API_BASE_URL =
 // API 엔드포인트 정의
 export const API_ENDPOINTS = {
   // 인증 관련
-  TOKEN: "api/token/",
-  TOKEN_REFRESH: "api/token/refresh/",
+  LOGIN: "sessions/", // api/token/ -> sessions/
+  //TOKEN_REFRESH: "api/token/refresh/",
   LOGOUT: "logout/",
 
   // 사용자 관련


### PR DESCRIPTION
## 📋 개요
- 로그인 api 변경(/api/token -> /sessions) 및 인증 엔드포인트를 apiConfig, token 파일에서 완전히 관리하도록 수정하였음
- 튜토리얼 완수 여부 변수에 저장

**관련 이슈:** 
- Resolves: #67 

---

## 🏷️ PR 유형
어떤 변경 사항이 있나요?

### 📱 기능 관련
- [x] 기존 기능 개선 및 수정
- [x] 버그 수정
